### PR TITLE
Fix NPE when getting error message and add HTTP response information

### DIFF
--- a/src/main/groovy/io/nextflow/gradle/registry/RegistryClient.groovy
+++ b/src/main/groovy/io/nextflow/gradle/registry/RegistryClient.groovy
@@ -1,7 +1,6 @@
 package io.nextflow.gradle.registry
 
 import com.google.gson.Gson
-import com.google.gson.JsonParseException
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import org.apache.http.client.methods.CloseableHttpResponse
@@ -38,7 +37,7 @@ class RegistryClient {
              def rep = http.execute(req)) {
 
             if (rep.statusLine.statusCode != 200) {
-                throw new RuntimeException(getErrorMessage(rep))
+                throw new RegistryPublishException(getErrorMessage(rep))
             }
         } catch (ConnectException e) {
             throw new RuntimeException("Unable to connect to plugin repository: (${e.message})")
@@ -50,23 +49,9 @@ class RegistryClient {
         if( rep.entity ) {
             final String entityStr = EntityUtils.toString(rep.entity)
             if (entityStr) {
-                try {
-                    def err = gson.fromJson(entityStr, ErrorResponse)
-                    if( err )
-                        return "$message - Error type: ${err.type}, message: ${err.message}".toString()
-                } catch( JsonParseException e ) {
-                    log.debug("Exception parsing error response: $e.message")
-                }
                 return "$message - $entityStr".toString()
             }
         }
         return message.toString()
-    }
-
-    // ----------------------------------------------------------------------------
-
-    private static class ErrorResponse {
-        String type
-        String message
     }
 }

--- a/src/main/groovy/io/nextflow/gradle/registry/RegistryPublishException.groovy
+++ b/src/main/groovy/io/nextflow/gradle/registry/RegistryPublishException.groovy
@@ -1,0 +1,10 @@
+package io.nextflow.gradle.registry
+
+/**
+ * Custom exception class for registry publish task
+ */
+class RegistryPublishException extends Exception{
+    RegistryPublishException(String s) {
+        super(s)
+    }
+}


### PR DESCRIPTION
close #3 
The current implementation assumes the request will return an HTTP response with an `ErrorResponse` serialized as JSON, but this only happens when the publish registry URL is correct. In other cases, the error response is null or throws a JSONParseException, hiding the real reason for the error.

This PR fixes this incorrect behaviour by checking the response content.
- If content matches with ErrorResponse, the message includes HTTP code, error type, and message
- If content doesn't match with ErrorResponse, the message includes the HTTP code and the content string
- If there is no content, it just returns the HTTP code
 