### PR TITLE
Update to plugin registry API v1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,10 +20,7 @@ dependencies {
     implementation 'org.apache.httpcomponents:httpmime:4.5.14'
 
     testImplementation('org.spockframework:spock-core:2.3-groovy-3.0')
-    testImplementation('org.spockframework:spock-junit4:2.1-groovy-3.0')
     testImplementation 'org.wiremock:wiremock:3.5.4'
-    testImplementation 'org.objenesis:objenesis:3.4'
-    testImplementation 'net.bytebuddy:byte-buddy:1.14.17'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,12 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'org.apache.httpcomponents:httpclient:4.5.14'
     implementation 'org.apache.httpcomponents:httpmime:4.5.14'
-    
+
     testImplementation('org.spockframework:spock-core:2.3-groovy-3.0')
+    testImplementation('org.spockframework:spock-junit4:2.1-groovy-3.0')
+    testImplementation 'org.wiremock:wiremock:3.5.4'
+    testImplementation 'org.objenesis:objenesis:3.4'
+    testImplementation 'net.bytebuddy:byte-buddy:1.14.17'
 }
 
 test {

--- a/src/main/groovy/io/nextflow/gradle/registry/RegistryClient.groovy
+++ b/src/main/groovy/io/nextflow/gradle/registry/RegistryClient.groovy
@@ -25,7 +25,7 @@ class RegistryClient {
     }
 
     def publish(String id, String version, File file) {
-        def req = new HttpPost(url.resolve("publish"))
+        def req = new HttpPost(url.resolve("v1/plugins/publish"))
         req.addHeader("Authorization", "Bearer ${authToken}")
         req.setEntity(MultipartEntityBuilder.create()
             .addTextBody("id", id)

--- a/src/main/groovy/io/nextflow/gradle/registry/RegistryPublishException.groovy
+++ b/src/main/groovy/io/nextflow/gradle/registry/RegistryPublishException.groovy
@@ -1,10 +1,16 @@
 package io.nextflow.gradle.registry
 
+import org.gradle.api.GradleException
+
 /**
  * Custom exception class for registry publish task
  */
-class RegistryPublishException extends Exception{
+class RegistryPublishException extends GradleException{
     RegistryPublishException(String s) {
         super(s)
+    }
+
+    RegistryPublishException(String string, Throwable e) {
+        super(string,e)
     }
 }


### PR DESCRIPTION
close #8

This PR modifies the Registry client to perform the plugin publication according to the V1 spec.

`POST /publish` -> `POST /v1/plugins/publish`

TODO:

- [x] Review error handling
- [x] Include tests
