### PR TITLE
Generate plugin index file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
-clean:
-	./gradlew clean
 
 assemble:
 	./gradlew assemble
+
+install:
+	./gradlew publishToMavenLocal
+
+clean:
+	./gradlew clean

--- a/src/main/groovy/io/nextflow/gradle/BuildIndexTask.groovy
+++ b/src/main/groovy/io/nextflow/gradle/BuildIndexTask.groovy
@@ -1,0 +1,40 @@
+package io.nextflow.gradle
+
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.OutputFile
+
+/**
+ * Gradle task to generate index file of the plugin definitions.
+ */
+class BuildIndexTask extends JavaExec {
+
+    @Input
+    final ListProperty<String> extensionPoints
+
+    @OutputFile
+    final RegularFileProperty outputFile
+
+    BuildIndexTask() {
+        extensionPoints = project.objects.listProperty(String)
+        extensionPoints.convention(project.provider {
+            project.extensions.getByType(NextflowPluginConfig).extensionPoints
+        })
+
+        outputFile = project.objects.fileProperty()
+        outputFile.convention(project.layout.buildDirectory.file("resources/main/META-INF/index.json"))
+
+        getMainClass().set('nextflow.plugin.index.PluginIndexWriter')
+
+        project.afterEvaluate {
+            setClasspath(project.sourceSets.getByName('indexFile').runtimeClasspath)
+            setArgs([outputFile.get().asFile.toString()] + extensionPoints.get())
+        }
+
+        doFirst {
+            outputFile.get().asFile.parentFile.mkdirs()
+        }
+    }
+}

--- a/src/main/groovy/io/nextflow/gradle/NextflowPlugin.groovy
+++ b/src/main/groovy/io/nextflow/gradle/NextflowPlugin.groovy
@@ -14,7 +14,9 @@ import org.gradle.jvm.toolchain.JavaLanguageVersion
  * A gradle plugin for nextflow plugin projects.
  */
 class NextflowPlugin implements Plugin<Project> {
+
     private static final int JAVA_TOOLCHAIN_VERSION = 21
+
     private static final int JAVA_VERSION = 17
 
     @Override
@@ -58,6 +60,11 @@ class NextflowPlugin implements Plugin<Project> {
             reps.maven { url = "https://s3-eu-west-1.amazonaws.com/maven.seqera.io/releases" }
         }
 
+        project.configurations {
+            indexFile
+            indexFileImplementation.extendsFrom(indexFile)
+        }
+
         project.afterEvaluate {
             config.validate()
             final nextflowVersion = config.nextflowVersion
@@ -86,6 +93,10 @@ class NextflowPlugin implements Plugin<Project> {
                 deps.testRuntimeOnly "net.bytebuddy:byte-buddy:1.14.17"
                 deps.testImplementation(testFixtures("io.nextflow:nextflow:${nextflowVersion}"))
                 deps.testImplementation(testFixtures("io.nextflow:nf-commons:${nextflowVersion}"))
+
+                // dependencies for buildIndex task
+                deps.indexFile "io.nextflow:nextflow:${nextflowVersion}"
+                deps.indexFile project.files(project.tasks.jar.archiveFile)
             }
         }
         // use JUnit 5 platform
@@ -106,6 +117,18 @@ class NextflowPlugin implements Plugin<Project> {
         project.tasks.register('extensionPoints', ExtensionPointsTask)
         project.tasks.jar.dependsOn << project.tasks.extensionPoints
         project.tasks.compileTestGroovy.dependsOn << project.tasks.extensionPoints
+
+        // buildIndex - generates an index file of plugin definitions
+        project.sourceSets.create('indexFile') { sourceSet ->
+            sourceSet.compileClasspath += project.configurations.getByName('indexFile')
+            sourceSet.runtimeClasspath += project.configurations.getByName('indexFile')
+        }
+        project.tasks.register('buildIndex', BuildIndexTask)
+        project.tasks.buildIndex.dependsOn << [
+            project.tasks.jar,
+            project.tasks.compileIndexFileGroovy
+        ]
+        project.tasks.buildIndex.outputs.cacheIf { true }
 
         // packagePlugin - builds the zip file
         project.tasks.register('packagePlugin', PluginPackageTask)


### PR DESCRIPTION
This PR adds a `buildIndex` task which generates a plugin index file using a custom entrypoint in the Nextflow runtime

It is a Java task that loads the Nextflow runtime (requires 25.08.0-edge or later) and the plugin that was just built, so that it can load the plugin extension points and generate the index file using the `PluginIndexWriter` class in the Nextflow runtime.

Depends on https://github.com/nextflow-io/nextflow/pull/6361

TODO:
- [ ] include the index JSON when publishing the plugin to the registry
- [ ] test with the registry