### PR TITLE
Add README.md requirement for registry publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,23 @@ export NPR_API_KEY=your-api-key
 
 The configuration precedence is: explicit values → project properties → environment variables → defaults.
 
+### README.md Requirement
+
+When publishing to the registry, your project must include a `README.md` file in the root directory. This file will be used as the plugin description in the registry.
+
+**Required sections:**
+1. **Summary** - Explain what the plugin does
+2. **Get Started** - Setup and configuration instructions
+3. **Examples** - Code examples with code blocks
+
+**Optional sections:**
+- **What's new** - Recent changes or new features
+- **Breaking changes** - Incompatible changes users should be aware of
+
+**Requirements:**
+- Content must be meaningful (no placeholder text like TODO, TBD, Lorem ipsum)
+- Content must be in English
+
 ### Available Tasks
 
 This will add some useful tasks to your Gradle build:

--- a/src/main/groovy/io/nextflow/gradle/registry/MissingReadmeException.groovy
+++ b/src/main/groovy/io/nextflow/gradle/registry/MissingReadmeException.groovy
@@ -1,0 +1,33 @@
+package io.nextflow.gradle.registry
+
+/**
+ * Exception thrown when README.md file is not found in the project root directory.
+ *
+ * This exception provides a detailed error message explaining what sections
+ * are required in the README.md file for plugin registry submission.
+ */
+class MissingReadmeException extends RegistryReleaseException {
+
+    private static final String MESSAGE = """
+            |README.md file not found in the project root directory.
+            |
+            |Please create a README.md file with the following required sections:
+            |  1. Summary: Explain what the plugin does
+            |  2. Get Started: Setup and configuration instructions
+            |  3. Examples: Code examples with code blocks
+            |
+            |Optional sections (include if relevant):
+            |  - What's new: Recent changes or new features
+            |  - Breaking changes: Incompatible changes users should be aware of
+            |
+            |Requirements:
+            |  - Content must be meaningful (no placeholder text like TODO, TBD, Lorem ipsum)
+            |  - Content must be in English
+            |
+            |This file will be used as the plugin description in the registry.
+            """.stripMargin().trim()
+
+    MissingReadmeException() {
+        super(MESSAGE)
+    }
+}

--- a/src/main/groovy/io/nextflow/gradle/registry/RegistryReleaseTask.groovy
+++ b/src/main/groovy/io/nextflow/gradle/registry/RegistryReleaseTask.groovy
@@ -51,10 +51,10 @@ class RegistryReleaseTask extends DefaultTask {
 
     /**
      * Executes the registry release task.
-     * 
+     *
      * This method retrieves the plugin configuration and creates a RegistryClient
      * to upload the plugin zip file to the configured registry endpoint.
-     * 
+     *
      * @throws RegistryReleaseException if the upload fails
      */
     @TaskAction
@@ -74,9 +74,25 @@ class RegistryReleaseTask extends DefaultTask {
         def registryUri = new URI(registryConfig.resolvedUrl)
         def client = new RegistryClient(registryUri, registryConfig.resolvedAuthToken)
         def specFileValue = specFile.isPresent() ? project.file(specFile) : null
-        client.release(project.name, version, specFileValue, project.file(zipFile), plugin.provider)
+        def description = readReadmeContent()
+        client.release(project.name, version, specFileValue, project.file(zipFile), plugin.provider, description)
 
         // Celebrate successful plugin upload! 🎉
         project.logger.lifecycle("🎉 SUCCESS! Plugin '${project.name}' version ${version} has been successfully released to Nextflow Registry [${registryUri}]!")
+    }
+
+    /**
+     * Reads the content of README.md file from the project directory.
+     *
+     * @return The content of README.md
+     * @throws RegistryReleaseException if README.md is not found
+     */
+    private String readReadmeContent() {
+        def readmeFile = project.file('README.md')
+        if (readmeFile.exists()) {
+            project.logger.debug("Reading description from README.md")
+            return readmeFile.text
+        }
+        throw new MissingReadmeException()
     }
 }


### PR DESCRIPTION
## Summary
- Add `MissingReadmeException` to centralize the README error message and avoid duplication between `RegistryReleaseTask` and `RegistryReleaseIfNotExistsTask`
- Pass description from README.md content to registry API during plugin release
- Update `RegistryClient` to include description field in draft release JSON payload
- Document README.md requirements in project README (required and optional sections)

## Test plan
- [x] Existing tests pass
- [x] Added new tests for description parameter handling in `RegistryClientTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)